### PR TITLE
 Added row reader retrieval for custom row reading 

### DIFF
--- a/SoulsFormats/Formats/PARAM/PARAM.cs
+++ b/SoulsFormats/Formats/PARAM/PARAM.cs
@@ -246,6 +246,16 @@ namespace SoulsFormats
         }
 
         /// <summary>
+        /// Returns a reader for the row passed for custom row reading logic
+        /// </summary>
+        public BinaryReaderEx GetRowReader(Row row)
+        {
+            RowReader.Position = row.DataOffset;
+
+            return RowReader;
+        }
+
+        /// <summary>
         /// Returns the first row with the given ID, or null if not found.
         /// </summary>
         public Row this[int id] => Rows.Find(row => row.ID == id);


### PR DESCRIPTION
During the transition of DSAnimStudio (https://github.com/Meowmaritus/DSAnimStudio/pull/7) to an extension to SoulsFormats instead of a fork of the above, I've encountered that some changes can't be moved outside of Formats, specifically the usage of custom PARAM.Row reader. 
This functionality seemed useful for other users of SoulsFormats so I'm proposing adding it to the master.